### PR TITLE
Change location per typology

### DIFF
--- a/Aberturas/app/controllers/dvhs_controller.rb
+++ b/Aberturas/app/controllers/dvhs_controller.rb
@@ -19,7 +19,7 @@ class DvhsController < ApplicationController
 
     def dvh_params
       params.require(:dvh).permit(
-        :innertube, :location, :height, :width,
+        :innertube, :typology, :height, :width,
         :glasscutting1_type, :glasscutting1_thickness, :glasscutting1_color,
         :glasscutting2_type, :glasscutting2_thickness, :glasscutting2_color,
         :price

--- a/Aberturas/app/controllers/glasscuttings_controller.rb
+++ b/Aberturas/app/controllers/glasscuttings_controller.rb
@@ -24,6 +24,6 @@ class GlasscuttingsController < ApplicationController
     end
 
     def glasscutting_params
-      params.require(:glasscutting).permit(:glass_type, :thickness, :height, :width, :color, :location, :price)
+      params.require(:glasscutting).permit(:glass_type, :thickness, :height, :width, :color, :typology, :price)
     end
 end

--- a/Aberturas/app/controllers/projects_controller.rb
+++ b/Aberturas/app/controllers/projects_controller.rb
@@ -72,10 +72,10 @@ class ProjectsController < ApplicationController
       :status,
       :price,
       :price_without_iva,
-      glasscuttings_attributes: [ :id, :glass_type, :thickness, :height, :width, :color, :location, :price ],
+      glasscuttings_attributes: [ :id, :glass_type, :thickness, :height, :width, :color, :typology, :price ],
       dvhs_attributes: [
         :innertube,
-        :location,
+        :typology,
         :height,
         :width,
         :glasscutting1_type,

--- a/Aberturas/app/helpers/projects_helper.rb
+++ b/Aberturas/app/helpers/projects_helper.rb
@@ -66,7 +66,7 @@ module ProjectsHelper
     project.as_json(
       only: [:id, :name, :description, :status, :delivery_date], 
       include: { 
-        glasscuttings: { only: [:id, :glass_type, :thickness, :color, :location, :height, :width] } 
+        glasscuttings: { only: [:id, :glass_type, :thickness, :color, :typology, :height, :width] } 
       }
     )
   end

--- a/Aberturas/app/javascript/dvh_table.js
+++ b/Aberturas/app/javascript/dvh_table.js
@@ -31,7 +31,7 @@ export function ensureDvhTable() {
         <tr class='bg-gray-50 text-gray-500'>
           <th class='px-2 py-1 text-left'>ID</th>
           <th class='px-2 py-1 text-left'>CÁMARA</th>
-          <th class='px-2 py-1 text-left'>UBICACIÓN</th>
+          <th class='px-2 py-1 text-left'>TIPOLOGÍA</th>
           <th class='px-2 py-1 text-left'>ALTO</th>
           <th class='px-2 py-1 text-left'>ANCHO</th>
           <th class='px-2 py-1 text-left'>CRISTAL 1</th>
@@ -68,6 +68,14 @@ export function handleDvhEvents(e) {
   // CONFIRM: Add new DVH entry to table
   if (e.target.classList.contains("confirm-dvh")) {
     const container = e.target.closest(".dvh-fields");
+    
+    // Before processing, ensure typology hidden field is updated
+    const typologyNumberInput = container.querySelector('.typology-number-input');
+    const typologyHidden = container.querySelector('.typology-hidden-field');
+    if (typologyNumberInput && typologyHidden && typologyNumberInput.value) {
+      typologyHidden.value = "V" + typologyNumberInput.value;
+    }
+    
     const fields = container.querySelectorAll("input, select");
     
     // Extract values from form inputs
@@ -110,7 +118,7 @@ export function handleDvhEvents(e) {
     tr.innerHTML = `
       <td class='px-2 py-1'>${dvhIdCounter}</td>
       <td class='px-2 py-1'>${values.innertube || ''}</td>
-      <td class='px-2 py-1'>${values.location || ''}</td>
+      <td class='px-2 py-1'>${values.typology || ''}</td>
       <td class='px-2 py-1'>${values.height || ''}</td>
       <td class='px-2 py-1'>${values.width || ''}</td>
       <td class='px-2 py-1'>${values.glasscutting1_type || ''} / ${values.glasscutting1_thickness || ''} / ${values.glasscutting1_color || ''}</td>
@@ -131,7 +139,7 @@ export function handleDvhEvents(e) {
     hiddenDiv.className = "dvh-hidden-row";
     hiddenDiv.innerHTML = `
       <input type="hidden" name="project[dvhs_attributes][][innertube]" value="${values.innertube || ''}">
-      <input type="hidden" name="project[dvhs_attributes][][location]" value="${values.location || ''}">
+      <input type="hidden" name="project[dvhs_attributes][][typology]" value="${values.typology || ''}">
       <input type="hidden" name="project[dvhs_attributes][][height]" value="${values.height || ''}">
       <input type="hidden" name="project[dvhs_attributes][][width]" value="${values.width || ''}">
       <input type="hidden" name="project[dvhs_attributes][][glasscutting1_type]" value="${values.glasscutting1_type || ''}">

--- a/Aberturas/app/javascript/glasscutting_table.js
+++ b/Aberturas/app/javascript/glasscutting_table.js
@@ -33,7 +33,7 @@ export function ensureGlasscuttingTable() {
           <th class='px-2 py-1 text-left'>TIPO</th>
           <th class='px-2 py-1 text-left'>GROSOR</th>
           <th class='px-2 py-1 text-left'>COLOR</th>
-          <th class='px-2 py-1 text-left'>UBICACIÓN</th>
+          <th class='px-2 py-1 text-left'>TIPOLOGIA</th>
           <th class='px-2 py-1 text-left'>ALTO</th>
           <th class='px-2 py-1 text-left'>ANCHO</th>
           <th class='px-2 py-1 text-left'>PRECIO</th>
@@ -68,12 +68,23 @@ export function handleGlasscuttingEvents(e) {
   // CONFIRM: Add new glass cutting entry to table
   if (e.target.classList.contains("confirm-glass")) {
     const container = e.target.closest(".glasscutting-fields");
+    
+    // Before processing, ensure typology hidden field is updated
+    const typologyNumberInput = container.querySelector('.typology-number-input');
+    const typologyHidden = container.querySelector('.typology-hidden-field');
+    if (typologyNumberInput && typologyHidden && typologyNumberInput.value) {
+      typologyHidden.value = "V" + typologyNumberInput.value;
+    }
+    
     const inputs = container.querySelectorAll("input, select");
     
     // Extract values from form inputs
     const values = {};
     inputs.forEach(input => {
-      values[input.name.split("[").pop().replace("]", "")] = input.value;
+      if (input.name) {
+        const fieldName = input.name.split("[").pop().replace("]", "");
+        values[fieldName] = input.value;
+      }
     });
     
     // Ensure table exists before adding row
@@ -95,7 +106,7 @@ export function handleGlasscuttingEvents(e) {
       <td class='px-2 py-1'>${values.glass_type || ''}</td>
       <td class='px-2 py-1'>${values.thickness || ''}</td>
       <td class='px-2 py-1'>${values.color || ''}</td>
-      <td class='px-2 py-1'>${values.location || ''}</td>
+      <td class='px-2 py-1'>${values.typology || ''}</td>
       <td class='px-2 py-1'>${values.height || ''}</td>
       <td class='px-2 py-1'>${values.width || ''}</td>
       <td class='px-2 py-1'>${price || ''}</td>
@@ -115,7 +126,7 @@ export function handleGlasscuttingEvents(e) {
       <input type="hidden" name="project[glasscuttings_attributes][][glass_type]" value="${values.glass_type || ''}">
       <input type="hidden" name="project[glasscuttings_attributes][][thickness]" value="${values.thickness || ''}">
       <input type="hidden" name="project[glasscuttings_attributes][][color]" value="${values.color || ''}">
-      <input type="hidden" name="project[glasscuttings_attributes][][location]" value="${values.location || ''}">
+      <input type="hidden" name="project[glasscuttings_attributes][][typology]" value="${values.typology || ''}">
       <input type="hidden" name="project[glasscuttings_attributes][][height]" value="${values.height || ''}">
       <input type="hidden" name="project[glasscuttings_attributes][][width]" value="${values.width || ''}">
     `;

--- a/Aberturas/app/javascript/projects_form.js
+++ b/Aberturas/app/javascript/projects_form.js
@@ -10,8 +10,22 @@ function handleAllEvents(e) {
   handleDvhEvents(e);
 }
 
+// Add input event listener for real-time typology updates
+function handleInputEvents(e) {
+  if (e.target.classList.contains('typology-number-input')) {
+    const container = e.target.closest('.glasscutting-fields, .dvh-fields');
+    if (container) {
+      const typologyHidden = container.querySelector('.typology-hidden-field');
+      if (typologyHidden) {
+        typologyHidden.value = e.target.value ? "V" + e.target.value : "";
+      }
+    }
+  }
+}
+
 if (!window._projectsFormEventRegistered) {
   document.addEventListener("click", handleAllEvents);
+  document.addEventListener("input", handleInputEvents);
   window._projectsFormEventRegistered = true;
 }
 
@@ -45,13 +59,21 @@ document.addEventListener('turbo:load', () => {
   }
 
   const newAddDvhBtn = document.getElementById('add-dvh');
+  console.log('DVH button found:', newAddDvhBtn);
   if (newAddDvhBtn) {
     newAddDvhBtn.addEventListener('click', () => {
-      const template = document.getElementById('dvh-template').content.cloneNode(true);
-      document.getElementById('dvhs-wrapper').appendChild(template);
+      console.log('DVH button clicked');
+      const template = document.getElementById('dvh-template');
+      console.log('DVH Template found:', template);
+      const templateContent = template.content.cloneNode(true);
+      console.log('DVH Template content:', templateContent);
+      const wrapper = document.getElementById('dvhs-wrapper');
+      console.log('DVH Wrapper found:', wrapper);
+      wrapper.appendChild(templateContent);
       setTimeout(() => {
         // Only the last added one
         const fields = document.querySelectorAll('.dvh-fields');
+        console.log('DVH Fields found:', fields.length);
         updateDvhGlassSelects(fields[fields.length - 1], 'glasscutting1');
         updateDvhGlassSelects(fields[fields.length - 1], 'glasscutting2');
       }, 0);

--- a/Aberturas/app/javascript/projects_inline_edit.js
+++ b/Aberturas/app/javascript/projects_inline_edit.js
@@ -33,8 +33,8 @@ export function setupProjectEditInline() {
     document.querySelectorAll('.glass-thickness-edit').forEach(e => e.style.display = editing ? '' : 'none');
     document.querySelectorAll('.glass-color-view').forEach(e => e.style.display = editing ? 'none' : '');
     document.querySelectorAll('.glass-color-edit').forEach(e => e.style.display = editing ? '' : 'none');
-    document.querySelectorAll('.glass-location-view').forEach(e => e.style.display = editing ? 'none' : '');
-    document.querySelectorAll('.glass-location-edit').forEach(e => e.style.display = editing ? '' : 'none');
+    document.querySelectorAll('.glass-typology-view').forEach(e => e.style.display = editing ? 'none' : '');
+    document.querySelectorAll('.glass-typology-edit').forEach(e => e.style.display = editing ? '' : 'none');
     document.querySelectorAll('.glass-height-view').forEach(e => e.style.display = editing ? 'none' : '');
     document.querySelectorAll('.glass-height-edit').forEach(e => e.style.display = editing ? '' : 'none');
     document.querySelectorAll('.glass-width-view').forEach(e => e.style.display = editing ? 'none' : '');
@@ -74,7 +74,7 @@ export function setupProjectEditInline() {
         glass_type: row.querySelector('.glass-type-edit').value,
         thickness: row.querySelector('.glass-thickness-edit').value,
         color: row.querySelector('.glass-color-edit').value,
-        location: row.querySelector('.glass-location-edit').value,
+        typology: row.querySelector('.glass-typology-edit').value,
         height: row.querySelector('.glass-height-edit').value,
         width: row.querySelector('.glass-width-edit').value
       });

--- a/Aberturas/app/models/dvh.rb
+++ b/Aberturas/app/models/dvh.rb
@@ -2,23 +2,11 @@ class Dvh < ApplicationRecord
   belongs_to :project
   #has_many :glasscuttings, dependent: :nullify
 
-  # Callbacks to update typologies when DVHs change
-  after_create :update_project_typologies
-  after_destroy :update_project_typologies
-
-  # Si usás glassplates como modelos separados, agregalos también
-  # belongs_to :glassplate1, class_name: "Glassplate", optional: true
-  # belongs_to :glassplate2, class_name: "Glassplate", optional: true
-
   validates :height, presence: { message: "El alto del vidrio no puede estar en blanco" }
   validates :width, presence: { message: "El ancho del vidrio no puede estar en blanco" }
   validates :height, numericality: { greater_than: 0, message: "El alto debe ser mayor que 0" }
   validates :width, numericality: { greater_than: 0, message: "El ancho debe ser mayor que 0" }
-
-  validates :location, inclusion: {
-    in: ["DINTEL", "JAMBA_I", "JAMBA_D", "UMBRAL"],
-    message: "La ubicación del vidrio no es valida",
-  }
+  validates :typology, presence: { message: "La tipología del DVH no puede estar en blanco" }
 
   validates :innertube, inclusion: {
     in: [6, 9, 12, 20],
@@ -90,13 +78,6 @@ class Dvh < ApplicationRecord
 
     self.price = (area_m2 * (price1 + price2)).round(2)
     Rails.logger.debug "Seteando precio DVH: #{self.price} (area: #{area_m2}, price1: #{price1}, price2: #{price2})"
-  end
-
-  private
-
-  # Update project typologies when DVH changes
-  def update_project_typologies
-    project.send(:assign_typologies) if project
   end
 
 end

--- a/Aberturas/app/models/glasscutting.rb
+++ b/Aberturas/app/models/glasscutting.rb
@@ -2,18 +2,15 @@ class Glasscutting < ApplicationRecord
   belongs_to :project 
   belongs_to :glassplate, optional: true 
 
-  # Callbacks to update typologies when glasscuttings change
-  after_create :update_project_typologies
-  after_destroy :update_project_typologies 
-
   # Validates that height and width are present and greater than 0
   validates :height, presence: { message: "El alto del vidrio no puede estar en blanco" }, numericality: { greater_than: 0, message: "El alto debe ser mayor que 0" } 
   validates :width, presence: { message: "El ancho del vidrio no puede estar en blanco" }, numericality: { greater_than: 0, message: "El ancho debe ser mayor que 0" } 
-  # Validates that glass_type, thickness, color, and location are present
+  # Validates that glass_type, thickness, color, and typology are present
   validates :glass_type, presence: { message: "El tipo de vidrio no puede estar en blanco" } 
   validates :thickness, presence: { message: "El espesor del vidrio no puede estar en blanco" } 
   validates :color, presence: { message: "El color del vidrio no puede estar en blanco" } 
-  validates :location, presence: { message: "La ubicación del vidrio no puede estar en blanco" } 
+  validates :typology, presence: { message: "La tipología del vidrio no puede estar en blanco" }
+
   validates :color, inclusion: {
     in: ["INC", "STB", "GRS", "BRC", "BLS", "STG", "NTR"],
     message: "Color de vidrio no valido"
@@ -27,11 +24,6 @@ class Glasscutting < ApplicationRecord
   validates :thickness, inclusion: {
     in: ["3+3", "4+4", "5+5", "5mm"],
     message: "El grosor del vidrios no es valido"
-  }
-
-  validates :location, inclusion: {
-    in: ["DINTEL", "JAMBA_I", "JAMBA_D", "UMBRAL"],
-    message: "La ubicación del vidrio no es valida"
   }
 
   before_save :set_price 
@@ -55,13 +47,6 @@ class Glasscutting < ApplicationRecord
     area_m2 = (height.to_f / 1000) * (width.to_f / 1000)
     self.price = (area_m2 * price_record.selling_price).round(2)
     Rails.logger.debug "Seteando precio: #{self.price}"
-  end
-
-  private
-
-  # Update project typologies when glasscutting changes
-  def update_project_typologies
-    project.send(:assign_typologies) if project
   end
 
 end

--- a/Aberturas/app/models/project.rb
+++ b/Aberturas/app/models/project.rb
@@ -7,9 +7,6 @@ class Project < ApplicationRecord
   accepts_nested_attributes_for :glasscuttings, allow_destroy: true
   accepts_nested_attributes_for :dvhs, allow_destroy: true
 
-  # Callbacks
-  after_save :assign_typologies
-
   # Validations
   validates :name, presence: { message: "El nombre del proyecto no puede estar en blanco", full_message: false }, length: { maximum: 100, message: "no puede tener más de %{count} caracteres", full_message: false }
   validates :phone, presence: { message: "El teléfono no puede estar en blanco", full_message: false }
@@ -82,22 +79,4 @@ class Project < ApplicationRecord
     end
   end
 
-  private
-
-  # Assign sequential typologies to glasscuttings and DVHs
-  def assign_typologies
-    counter = 1
-    
-    # First, assign typologies to glasscuttings (reset all)
-    glasscuttings.order(:id).each do |glasscutting|
-      glasscutting.update_column(:typology, "V#{counter}")
-      counter += 1
-    end
-    
-    # Then, assign typologies to DVHs continuing the count (reset all)
-    dvhs.order(:id).each do |dvh|
-      dvh.update_column(:typology, "V#{counter}")
-      counter += 1
-    end
-  end
 end

--- a/Aberturas/app/views/projects/new.html.erb
+++ b/Aberturas/app/views/projects/new.html.erb
@@ -62,14 +62,13 @@
       </select>
     </div>
     <div>
-      <label>Ubicación</label>
-      <select name="project[glasscuttings_attributes][][location]" class="w-full border rounded px-2 py-1 glass-location-select">
-        <option value="">Seleccionar</option>
-        <option value="UMBRAL">UMBRAL</option>
-        <option value="DINTEL">DINTEL</option>
-        <option value="JAMBA_I">JAMBA_I</option>
-        <option value="JAMBA_D">JAMBA_D</option>
-      </select>
+      <label>Tipología</label>
+      <div class="flex items-center border rounded px-2 py-1">
+        <span class="text-gray-700 font-medium mr-1">V</span>
+        <input type="number" class="flex-1 border-0 outline-none typology-number-input" placeholder="1" min="1" 
+               oninput="this.parentElement.querySelector('.typology-hidden-field').value = this.value ? 'V' + this.value : ''" />
+        <input type="hidden" name="project[glasscuttings_attributes][][typology]" class="typology-hidden-field" value="" />
+      </div>
     </div>
     <div class="actions space-x-2 mt-2 col-span-2 flex gap-2">
       <button type="button" class="confirm-glass bg-black text-white px-3 py-1 rounded mt-4">Confirmar</button>
@@ -84,7 +83,7 @@
   <div class="border border-gray-300 rounded p-4 mb-4 dvh-fields space-y-4">
 
     <!-- Row 1: Basic DVH information -->
-    <!--  First row: basic DVH information (innertube, location, width, height) -->
+    <!--  First row: basic DVH information (innertube, typology, width, height) -->
     <div class="grid grid-cols-5 gap-4">
       <div>
         <label>Cámara</label>
@@ -97,14 +96,13 @@
         </select>
       </div>
       <div>
-        <label>Ubicación</label>
-        <select name="project[dvhs_attributes][][location]" class="w-full border rounded px-2 py-1 glass-location-select">
-          <option value="">Seleccionar</option>
-          <option value="UMBRAL">UMBRAL</option>
-          <option value="DINTEL">DINTEL</option>
-          <option value="JAMBA_I">JAMBA_I</option>
-          <option value="JAMBA_D">JAMBA_D</option>
-        </select>
+        <label>Tipología</label>
+        <div class="flex items-center border rounded px-2 py-1">
+          <span class="text-gray-700 font-medium mr-1">V</span>
+          <input type="number" class="flex-1 border-0 outline-none typology-number-input" placeholder="1" min="1" 
+                 oninput="this.parentElement.querySelector('.typology-hidden-field').value = this.value ? 'V' + this.value : ''" />
+          <input type="hidden" name="project[dvhs_attributes][][typology]" class="typology-hidden-field" value="" />
+        </div>
       </div>
       <div>
         <label>Ancho</label>

--- a/Aberturas/app/views/projects/partials/_dvhs_table.html.erb
+++ b/Aberturas/app/views/projects/partials/_dvhs_table.html.erb
@@ -1,11 +1,10 @@
-<%# Table displaying all DVH records for the project %>
+<%# Static table displaying all DVH (Double-glazed window) records for the project %>
 <table class="min-w-full divide-y divide-gray-200 bg-white rounded-lg border border-gray-200 shadow p-4 overflow-hidden">
   <thead class="bg-gray-50">
     <tr>
-      <%# Column headers: ID, Chamber, Location, Height, Width, Glass 1, Glass 2 %>
-      <th class="px-2 py-1 text-center text-xs font-medium text-gray-500 uppercase">TIPOLOGIA</th>
+      <%# Table headers: Typology, Chamber, Height, Width, Glass 1, Glass 2, Price %>
+      <th class="px-2 py-1 text-center text-xs font-medium text-gray-500 uppercase">TIPOLOGÍA</th>
       <th class="px-2 py-1 text-center text-xs font-medium text-gray-500 uppercase">CÁMARA</th>
-      <th class="px-2 py-1 text-center text-xs font-medium text-gray-500 uppercase">UBICACIÓN</th>
       <th class="px-2 py-1 text-center text-xs font-medium text-gray-500 uppercase">ALTO</th>
       <th class="px-2 py-1 text-center text-xs font-medium text-gray-500 uppercase">ANCHO</th>
       <th class="px-2 py-1 text-center text-xs font-medium text-gray-500 uppercase">CRISTAL 1</th>
@@ -14,30 +13,25 @@
     </tr>
   </thead>
   <tbody class="divide-y divide-gray-100" id="dvhs-table-body">
-    <%# Iterate over each DVH in the project and display its attributes %>
+    <%# Iterate through each DVH in the project and display its attributes %>
     <% project.dvhs.each_with_index do |dvh, idx| %>
       <tr>
-        <%# Typology (V1, V2, etc.) %>
-        <td class="text-center px-2 py-1 font-semibold">
-          <%= dvh.typology || "V#{project.glasscuttings.count + idx + 1}" %>
-        </td>
-        <%# Chamber (innertube) %>
+        <%# Typology - Free text field for custom window identification (V1, V2, V5, etc.) %>
+        <td class="text-center px-2 py-1"><%= dvh.typology %></td>
+        <%# Chamber size (innertube) in millimeters %>
         <td class="text-center px-2 py-1"><%= dvh.innertube %></td>
-        <%# Location %>
-        <td class="text-center px-2 py-1"><%= dvh.location %></td>
-        <%# Height %>
+        <%# Dimensions in millimeters %>
         <td class="text-center px-2 py-1"><%= dvh.height %></td>
-        <%# Width %>
         <td class="text-center px-2 py-1"><%= dvh.width %></td>
-        <%# Glass 1: type / thickness / color %>
+        <%# Glass 1 specifications: combines type, thickness, and color with separators %>
         <td class="text-center px-2 py-1">
           <%= [dvh.glasscutting1_type, dvh.glasscutting1_thickness, dvh.glasscutting1_color].compact.join(' / ') %>
         </td>
-        <%# Glass 2: type / thickness / color %>
+        <%# Glass 2 specifications: combines type, thickness, and color with separators %>
         <td class="text-center px-2 py-1">
           <%= [dvh.glasscutting2_type, dvh.glasscutting2_thickness, dvh.glasscutting2_color].compact.join(' / ') %>
         </td>
-        <%# Price %>
+        <%# Price formatted as currency if present %>
         <td class="text-center px-2 py-1">
           <%= number_to_currency(dvh.price, unit: "$", precision: 2) if dvh.price.present? %>
         </td>

--- a/Aberturas/app/views/projects/partials/_glasscuttings_table.html.erb
+++ b/Aberturas/app/views/projects/partials/_glasscuttings_table.html.erb
@@ -1,46 +1,52 @@
+<%# Static table displaying all glasscutting records for the project with inline editing capability %>
 <table class="min-w-full divide-y divide-gray-200 bg-white rounded-lg border border-gray-200 shadow p-4 overflow-hidden">
   <thead class="bg-gray-50">
     <tr>
-      <th class="px-4 py-2 text-center text-xs font-medium text-gray-500 uppercase">Tipologia</th>
+      <%# Table headers for glasscutting attributes %>
+      <th class="px-4 py-2 text-center text-xs font-medium text-gray-500 uppercase">Tipología</th>
       <th class="px-6 py-2 text-center text-xs font-medium text-gray-500 uppercase">Tipo</th>
       <th class="px-4 py-2 text-center text-xs font-medium text-gray-500 uppercase">Espesor</th>
       <th class="px-4 py-2 text-center text-xs font-medium text-gray-500 uppercase">Color</th>
-      <th class="px-4 py-2 text-center text-xs font-medium text-gray-500 uppercase">Ubicación</th>
       <th class="px-4 py-2 text-center text-xs font-medium text-gray-500 uppercase">Alto</th>
       <th class="px-4 py-2 text-center text-xs font-medium text-gray-500 uppercase">Ancho</th>
       <th class="px-4 py-2 text-center text-xs font-medium text-gray-500 uppercase">Precio</th>
     </tr>
   </thead>
   <tbody class="divide-y divide-gray-100" id="glasscuttings-table-body">
+    <%# Iterate through each glasscutting record and create editable rows %>
     <% project.glasscuttings.each_with_index do |glass, idx| %>
       <tr>
-        <td class="text-center px-4 py-2 font-semibold">
-          <%= glass.typology || "V#{idx + 1}" %>
+        <%# Typology field - Free text input for custom glass identification (V1, V2, V5, etc.) %>
+        <td class="text-center px-4 py-2">
+          <span class="glass-typology-view"><%= glass.typology %></span>
+          <input type="text" class="glass-typology-edit w-full border rounded px-2 py-2 text-base" value="<%= glass.typology %>" style="display:none;" data-idx="<%= idx %>" data-id="<%= glass.id %>" />
         </td>
+        <%# Glass type field with view/edit toggle %>
         <td class="text-center px-4 py-2">
           <span class="glass-type-view"><%= glass.glass_type %></span>
           <input type="text" class="glass-type-edit w-full border rounded px-2 py-2 text-base" value="<%= glass.glass_type %>" style="display:none;" data-idx="<%= idx %>" data-id="<%= glass.id %>" />
         </td>
+        <%# Glass thickness field with view/edit toggle %>
         <td class="text-center px-4 py-2">
           <span class="glass-thickness-view"><%= glass.thickness %></span>
           <input type="text" class="glass-thickness-edit w-full border rounded px-2 py-2 text-base" value="<%= glass.thickness %>" style="display:none;" data-idx="<%= idx %>" data-id="<%= glass.id %>" />
         </td>
+        <%# Glass color field with view/edit toggle %>
         <td class="text-center px-4 py-2">
           <span class="glass-color-view"><%= glass.color %></span>
           <input type="text" class="glass-color-edit w-full border rounded px-2 py-2 text-base" value="<%= glass.color %>" style="display:none;" data-idx="<%= idx %>" data-id="<%= glass.id %>" />
         </td>
-        <td class="text-center px-4 py-2">
-          <span class="glass-location-view"><%= glass.location %></span>
-          <input type="text" class="glass-location-edit w-full border rounded px-2 py-2 text-base" value="<%= glass.location %>" style="display:none;" data-idx="<%= idx %>" data-id="<%= glass.id %>" />
-        </td>
+        <%# Height field with view/edit toggle (numeric input) %>
         <td class="text-center px-4 py-2">
           <span class="glass-height-view"><%= glass.height %></span>
           <input type="number" class="glass-height-edit w-full border rounded px-2 py-2 text-base" value="<%= glass.height %>" style="display:none;" data-idx="<%= idx %>" data-id="<%= glass.id %>" />
         </td>
+        <%# Width field with view/edit toggle (numeric input) %>
         <td class="text-center px-4 py-2">
           <span class="glass-width-view"><%= glass.width %></span>
           <input type="number" class="glass-width-edit w-full border rounded px-2 py-2 text-base" value="<%= glass.width %>" style="display:none;" data-idx="<%= idx %>" data-id="<%= glass.id %>" />
         </td>
+        <%# Price field (read-only, calculated automatically) %>
         <td class="text-center px-4 py-2">
           <%= number_to_currency(glass.price, unit: "$", precision: 2) if glass.price.present? %>
         </td>

--- a/Aberturas/app/views/projects/partials/_info_dvhs.html.erb
+++ b/Aberturas/app/views/projects/partials/_info_dvhs.html.erb
@@ -9,65 +9,6 @@
 
     <!-- Formulario de creación de DVH -->
     <div id="dvhs-wrapper">
-      <% f.fields_for :dvhs do |dvh| %>
-        <!-- DVH form row with improved labels -->
-        <div class="grid grid-cols-7 gap-4 mb-4 dvh-fields">
-          <label>Cámara</label>
-          <select name="project[dvhs_attributes][][innertube]" class="w-full border rounded px-2 py-1">
-            <option value="">Seleccionar</option>
-            <option value="6">6</option>
-            <option value="9">9</option>
-            <option value="12">12</option>
-            <option value="20">20</option>
-          </select>          
-          <div>
-            <%= dvh.label :location, "Ubicación" %>
-            <select name="project[dvhs_attributes][][location]" class="w-full border rounded px-2 py-1">
-              <option value="">Seleccionar</option>
-              <option value="DINTEL">DINTEL</option>
-              <option value="JAMBA_I">JAMBA_I</option>
-              <option value="JAMBA_D">JAMBA_D</option>
-              <option value="UMBRAL">UMBRAL</option>
-            </select>
-          </div>
-          <div><%= dvh.label :height, "Alto (mm)" %> <%= dvh.number_field :height, class: "w-full border rounded px-2 py-1" %></div>
-          <div><%= dvh.label :width, "Ancho (mm)" %> <%= dvh.number_field :width, class: "w-full border rounded px-2 py-1" %></div>
-          <div>
-            <%= dvh.label :glasscutting1_type, "Tipo vidrio 1" %>
-            <select class="glasscutting1-type-select w-full border rounded px-2 py-1 mb-1" name="glasscutting1_type">
-              <option value="">Seleccionar</option>
-              <option value="LAM" <%= 'selected' if dvh.object.glasscutting1_type == "LAM" %>>LAM</option>
-              <option value="FLO" <%= 'selected' if dvh.object.glasscutting1_type == "FLO" %>>FLO</option>
-              <option value="COL" <%= 'selected' if dvh.object.glasscutting1_type == "COL" %>>COL</option>
-            </select>
-            <select class="glasscutting1-thickness-select w-full border rounded px-2 py-1 mb-1" name="glasscutting1_thickness">
-              <option value=""><%= dvh.object.glasscutting1_thickness.presence || 'Seleccionar espesor' %></option>
-            </select>
-            <select class="glasscutting1-color-select w-full border rounded px-2 py-1" name="glasscutting1_color">
-              <option value=""><%= dvh.object.glasscutting1_color.presence || 'Seleccionar color' %></option>
-            </select>
-          </div>
-          <div>
-            <%= dvh.label :glasscutting2_type, "Tipo vidrio 2" %>
-            <select class="glasscutting2-type-select w-full border rounded px-2 py-1 mb-1" name="glasscutting2_type">
-              <option value="">Seleccionar tipo</option>
-              <option value="LAM" <%= 'selected' if dvh.object.glasscutting2_type == "LAM" %>>LAM</option>
-              <option value="FLO" <%= 'selected' if dvh.object.glasscutting2_type == "FLO" %>>FLO</option>
-              <option value="COL" <%= 'selected' if dvh.object.glasscutting2_type == "COL" %>>COL</option>
-            </select>
-            <select class="glasscutting2-thickness-select w-full border rounded px-2 py-1 mb-1" name="glasscutting2_thickness">
-              <option value=""><%= dvh.object.glasscutting2_thickness.presence || 'Seleccionar espesor' %></option>
-            </select>
-            <select class="glasscutting2-color-select w-full border rounded px-2 py-1" name="glasscutting2_color">
-              <option value=""><%= dvh.object.glasscutting2_color.presence || 'Seleccionar color' %></option>
-            </select>
-          </div>
-          <div class="actions space-x-2 mt-2 flex gap-2">
-            <%= button_tag "Confirmar", type: "button", class: "confirm-dvh bg-black text-white px-3 py-1 rounded mt-4" %>
-            <%= button_tag "Cancelar", type: "button", class: "cancel-dvh bg-gray-100 text-gray-800 px-3 py-1 rounded mt-4" %>
-          </div>
-        </div>
-      <% end %>
     </div>
 
     <!-- Botón para agregar nuevo DVH -->

--- a/Aberturas/app/views/projects/partials/_info_glasscuttings.html.erb
+++ b/Aberturas/app/views/projects/partials/_info_glasscuttings.html.erb
@@ -1,57 +1,20 @@
-<!-- glasscuttings table section -->
+<!-- Glass cutting section for project creation -->
+<!-- This section handles dynamic creation and display of simple glass cutting entries -->
 <div class="bg-white rounded-md border border-gray-200 shadow-sm p-4 mt-7">
     <h2 class="text-base font-semibold mb-4">Vidrios simples</h2>
 
+    <!-- Container for dynamically generated glasscutting table -->
     <div id="glasscuttings-table-container"></div>
 
-    <!-- Contenedor para los inputs ocultos de vidrios confirmados -->
+    <!-- Container for hidden form inputs of confirmed glasscutting entries -->
+    <!-- These inputs are submitted with the main form to create glasscutting records -->
     <div id="glasscuttings-hidden"></div>
 
-    <!-- Formulario de creación de vidrio simple -->
+    <!-- Container for dynamically generated glasscutting entry forms -->
+    <!-- JavaScript will clone template content and append it here -->
     <div id="glasscuttings-wrapper">
-      <%= f.fields_for :glasscuttings do |gc| %>
-        <div class="grid grid-cols-8 gap-4 mb-4 glasscutting-fields">
-          <div>
-            <%= gc.label :glass_type, "Tipo de vidrio" %>
-            <select class="w-full border rounded px-2 py-1 glass-type-select" name="project[glasscuttings_attributes][][glass_type]">
-              <option value="">Seleccionar</option>
-              <option value="LAM">LAM</option>
-              <option value="FLO">FLO</option>
-              <option value="COL">COL</option>
-            </select>
-          </div>
-          <div>
-            <%= gc.label :thickness, "Grosor" %>
-            <select class="w-full border rounded px-2 py-1 glass-thickness-select" name="project[glasscuttings_attributes][][thickness]">
-              <option value="">Seleccionar</option>
-            </select>
-          </div>
-          <div>
-            <%= gc.label :color, "Color" %>
-            <select class="w-full border rounded px-2 py-1 glass-color-select" name="project[glasscuttings_attributes][][color]">
-              <option value="">Seleccionar</option>
-            </select>
-          </div>
-          <div>
-            <%= gc.label :location, "Ubicación" %>
-            <select class="w-full border rounded px-2 py-1 glass-location-select" name="project[glasscuttings_attributes][][location]">
-              <option value="">Seleccionar</option>
-              <option value="UMBRAL">UMBRAL</option>
-              <option value="DINTEL">DINTEL</option>
-              <option value="JAMBA_I">JAMBA_I</option>
-              <option value="JAMBA_D">JAMBA_D</option>
-            </select>
-          </div>
-          <div><%= gc.label :height, "Alto (mm)" %> <%= gc.number_field :height, class: "w-full border rounded px-2 py-1" %></div>
-          <div><%= gc.label :width, "Ancho (mm)" %> <%= gc.number_field :width, class: "w-full border rounded px-2 py-1" %></div>
-          <div class="actions space-x-2 mt-2 col-span-2 flex gap-2">
-            <%= button_tag "Confirmar", type: "button", class: "confirm-glass bg-black text-white px-3 py-1 rounded mt-4" %>
-            <%= button_tag "Cancelar", type: "button", class: "cancel-glass bg-gray-100 text-gray-800 px-3 py-1 rounded mt-4" %>
-          </div>
-        </div>
-      <% end %>
     </div>
 
-    <!-- Botón para agregar nuevo vidrio simple -->
+    <!-- Button to trigger creation of new glasscutting entry form -->
     <%= button_tag "Agregar vidrio simple", type: "button", id: "add-glasscutting", class: "mt-4 bg-black text-white px-4 py-2 rounded" %>
 </div>

--- a/Aberturas/config/locales/es.yml
+++ b/Aberturas/config/locales/es.yml
@@ -9,7 +9,7 @@ es:
         delivery_date: ""
       dvh:
         innertube: ""
-        location: ""
+        typology: ""
         height: ""
         width: ""
         glasscutting1_type: ""
@@ -24,7 +24,7 @@ es:
         height: ""
         width: ""
         color: ""
-        location: ""
+        typology: ""
         price: ""
       glasscuttings:
         glass_type: ""
@@ -32,7 +32,7 @@ es:
         height: ""
         width: ""
         color: ""
-        location: ""
+        typology: ""
         price: ""
     models:
       glasscutting: ""

--- a/Aberturas/db/migrate/20250803154358_remove_location_from_glasscuttings_and_dvhs.rb
+++ b/Aberturas/db/migrate/20250803154358_remove_location_from_glasscuttings_and_dvhs.rb
@@ -1,0 +1,6 @@
+class RemoveLocationFromGlasscuttingsAndDvhs < ActiveRecord::Migration[8.0]
+  def change
+    remove_column :glasscuttings, :location, :string
+    remove_column :dvhs, :location, :string
+  end
+end

--- a/Aberturas/db/schema.rb
+++ b/Aberturas/db/schema.rb
@@ -10,13 +10,19 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2025_07_29_032005) do
+ActiveRecord::Schema[8.0].define(version: 2025_08_03_154358) do
+  create_table "app_configs", force: :cascade do |t|
+    t.string "key"
+    t.string "value"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+  end
+
   create_table "dvhs", force: :cascade do |t|
     t.integer "project_id", null: false
     t.integer "innertube"
     t.float "height"
     t.float "width"
-    t.string "location"
     t.decimal "price"
     t.string "glasscutting1_type"
     t.string "glasscutting1_thickness"
@@ -47,7 +53,6 @@ ActiveRecord::Schema[8.0].define(version: 2025_07_29_032005) do
     t.string "color"
     t.string "glass_type"
     t.string "thickness"
-    t.string "location"
     t.decimal "price"
     t.integer "project_id", null: false
     t.integer "dvh_id"
@@ -94,9 +99,12 @@ ActiveRecord::Schema[8.0].define(version: 2025_07_29_032005) do
 
   create_table "supplies", force: :cascade do |t|
     t.string "name"
-    t.decimal "price"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.decimal "price_usd", precision: 10, scale: 2, default: "0.0", null: false
+    t.decimal "price_peso", precision: 10, scale: 2, default: "0.0", null: false
+    t.index ["price_peso"], name: "index_supplies_on_price_peso"
+    t.index ["price_usd"], name: "index_supplies_on_price_usd"
   end
 
   add_foreign_key "dvhs", "projects"

--- a/Aberturas/test/fixtures/dvhs.yml
+++ b/Aberturas/test/fixtures/dvhs.yml
@@ -2,8 +2,28 @@
 
 one:
   project: one
-  innertube: 1
+  innertube: 6
+  typology: V1
+  height: 1000
+  width: 800
+  glasscutting1_type: LAM
+  glasscutting1_thickness: 3+3
+  glasscutting1_color: INC
+  glasscutting2_type: FLO
+  glasscutting2_thickness: 4+4
+  glasscutting2_color: GRS
+  price: 299.99
 
 two:
   project: two
-  innertube: 1
+  innertube: 9
+  typology: V2
+  height: 1200
+  width: 600
+  glasscutting1_type: COL
+  glasscutting1_thickness: 5+5
+  glasscutting1_color: BRC
+  glasscutting2_type: LAM
+  glasscutting2_thickness: 3+3
+  glasscutting2_color: STB
+  price: 399.99

--- a/Aberturas/test/fixtures/glasscuttings.yml
+++ b/Aberturas/test/fixtures/glasscuttings.yml
@@ -3,9 +3,10 @@
 one:
   height: 1.5
   width: 1.5
-  color: MyString
-  glass_type: MyString
-  location: MyString
+  color: INC
+  glass_type: LAM
+  thickness: 3+3
+  typology: V1
   price: 9.99
   project: one
   #glassplate: one
@@ -13,9 +14,10 @@ one:
 two:
   height: 1.5
   width: 1.5
-  color: MyString
-  glass_type: MyString
-  location: MyString
+  color: GRS
+  glass_type: FLO
+  thickness: 4+4
+  typology: V2
   price: 9.99
   project: two
   #glassplate: two

--- a/Aberturas/test/models/dvh_test.rb
+++ b/Aberturas/test/models/dvh_test.rb
@@ -6,7 +6,7 @@ class DvhTest < ActiveSupport::TestCase
     @dvh = Dvh.new(
       project: @project,
       innertube: "6",
-      location: "DINTEL",
+      typology: "V1",
       height: 1000,
       width: 800,
       glasscutting1_type: "LAM",
@@ -30,10 +30,10 @@ class DvhTest < ActiveSupport::TestCase
     assert_includes @dvh.errors[:innertube], "La camara del vidrio no es valida"
   end
 
-  test "should require location" do
-    @dvh.location = nil
+  test "should require typology" do
+    @dvh.typology = nil
     assert_not @dvh.valid?
-    assert_includes @dvh.errors[:location], "La ubicación del vidrio no es valida"
+    assert_includes @dvh.errors[:typology], "La tipología del DVH no puede estar en blanco"
   end
 
   test "should require height and width" do
@@ -44,10 +44,14 @@ class DvhTest < ActiveSupport::TestCase
     assert_includes @dvh.errors[:width], "El ancho del vidrio no puede estar en blanco"
   end
 
-  test "should validate location inclusion" do
-    @dvh.location = "INVALID_LOCATION"
-    assert_not @dvh.valid?
-    assert_includes @dvh.errors[:location], "La ubicación del vidrio no es valida"
+  test "should allow any typology format" do
+    # Test various typology formats
+    valid_typologies = ["V1", "V10", "V123", "V5", "Custom1", "ABC123"]
+    
+    valid_typologies.each do |typology|
+      @dvh.typology = typology
+      assert @dvh.valid?, "Typology '#{typology}' should be valid"
+    end
   end
 
   test "should validate innertube inclusion" do
@@ -89,14 +93,14 @@ class DvhTest < ActiveSupport::TestCase
 
     # Create a glasscutting first
     glasscutting = project.glasscuttings.create!(
-      glass_type: "LAM", thickness: "4+4", color: "INC", location: "DINTEL",
+      glass_type: "LAM", thickness: "4+4", color: "INC", typology: "V1",
       height: 100, width: 50, price: 100.0
     )
 
     # Create DVH
     dvh = project.dvhs.create!(
       innertube: 9,
-      location: "DINTEL",
+      typology: "V2",
       height: 150,
       width: 100,
       glasscutting1_type: "LAM",
@@ -117,7 +121,7 @@ class DvhTest < ActiveSupport::TestCase
     assert_equal "V2", dvh.typology
   end
 
-  test "should trigger typology update on destroy" do
+  test "should maintain typology on destroy" do
     project = Project.create!(
       name: "Test Project",
       phone: "123456789",
@@ -126,19 +130,19 @@ class DvhTest < ActiveSupport::TestCase
 
     # Create glasscutting and two DVHs
     glasscutting = project.glasscuttings.create!(
-      glass_type: "LAM", thickness: "4+4", color: "INC", location: "DINTEL",
+      glass_type: "LAM", thickness: "4+4", color: "INC", typology: "V1",
       height: 100, width: 50, price: 100.0
     )
 
     dvh1 = project.dvhs.create!(
-      innertube: 9, location: "DINTEL", height: 150, width: 100,
+      innertube: 9, typology: "V2", height: 150, width: 100,
       glasscutting1_type: "LAM", glasscutting1_thickness: "4+4", glasscutting1_color: "INC",
       glasscutting2_type: "FLO", glasscutting2_thickness: "3+3", glasscutting2_color: "GRS",
       price: 300.0
     )
 
     dvh2 = project.dvhs.create!(
-      innertube: 12, location: "JAMBA_I", height: 200, width: 150,
+      innertube: 12, typology: "V3", height: 200, width: 150,
       glasscutting1_type: "COL", glasscutting1_thickness: "5+5", glasscutting1_color: "BRC",
       glasscutting2_type: "LAM", glasscutting2_thickness: "4+4", glasscutting2_color: "STB",
       price: 400.0
@@ -157,10 +161,10 @@ class DvhTest < ActiveSupport::TestCase
     # Destroy first DVH
     dvh1.destroy!
 
-    # Second DVH should become V2
+    # Second DVH should keep its typology unchanged
     glasscutting.reload
     dvh2.reload
     assert_equal "V1", glasscutting.typology
-    assert_equal "V2", dvh2.typology
+    assert_equal "V3", dvh2.typology
   end
 end

--- a/Aberturas/test/models/glasscutting_test.rb
+++ b/Aberturas/test/models/glasscutting_test.rb
@@ -10,7 +10,7 @@ class GlasscuttingTest < ActiveSupport::TestCase
       height: 1000,
       width: 800,
       color: "INC",
-      location: "DINTEL"
+      typology: "V1"
     )
   end
 
@@ -36,10 +36,10 @@ class GlasscuttingTest < ActiveSupport::TestCase
     assert_includes @glasscutting.errors[:color], "El color del vidrio no puede estar en blanco"
   end
 
-  test "should require location" do
-    @glasscutting.location = nil
+  test "should require typology" do
+    @glasscutting.typology = nil
     assert_not @glasscutting.valid?
-    assert_includes @glasscutting.errors[:location], "La ubicación del vidrio no puede estar en blanco"
+    assert_includes @glasscutting.errors[:typology], "La tipología del vidrio no puede estar en blanco"
   end
 
   test "should require height and width" do
@@ -68,11 +68,14 @@ class GlasscuttingTest < ActiveSupport::TestCase
     assert_includes @glasscutting.errors[:color], "Color de vidrio no valido"
   end
 
-  test "should validate location inclusion" do
-    @glasscutting.location = "INVALID"
-    assert_not @glasscutting.valid?
-    assert_includes @glasscutting.errors[:location], "La ubicación del vidrio no es valida"
-
+  test "should allow any typology format" do
+    # Test various typology formats
+    valid_typologies = ["V1", "V10", "V123", "V5", "Custom1", "ABC123"]
+    
+    valid_typologies.each do |typology|
+      @glasscutting.typology = typology
+      assert @glasscutting.valid?, "Typology '#{typology}' should be valid"
+    end
   end
 
   test "should trigger typology update on create" do
@@ -87,7 +90,7 @@ class GlasscuttingTest < ActiveSupport::TestCase
       glass_type: "LAM",
       thickness: "4+4",
       color: "INC",
-      location: "DINTEL",
+      typology: "V1",
       height: 100,
       width: 50,
       price: 100.0
@@ -102,7 +105,7 @@ class GlasscuttingTest < ActiveSupport::TestCase
       glass_type: "FLO",
       thickness: "3+3",
       color: "GRS",
-      location: "JAMBA_I",
+      typology: "V2",
       height: 200,
       width: 75,
       price: 200.0
@@ -115,7 +118,7 @@ class GlasscuttingTest < ActiveSupport::TestCase
     assert_equal "V2", glasscutting2.typology
   end
 
-  test "should trigger typology update on destroy" do
+  test "should maintain typology on destroy" do
     project = Project.create!(
       name: "Test Project",
       phone: "123456789",
@@ -124,12 +127,12 @@ class GlasscuttingTest < ActiveSupport::TestCase
 
     # Create two glasscuttings
     glasscutting1 = project.glasscuttings.create!(
-      glass_type: "LAM", thickness: "4+4", color: "INC", location: "DINTEL",
+      glass_type: "LAM", thickness: "4+4", color: "INC", typology: "V1",
       height: 100, width: 50, price: 100.0
     )
     
     glasscutting2 = project.glasscuttings.create!(
-      glass_type: "FLO", thickness: "3+3", color: "GRS", location: "JAMBA_I",
+      glass_type: "FLO", thickness: "3+3", color: "GRS", typology: "V2",
       height: 200, width: 75, price: 200.0
     )
 
@@ -144,8 +147,8 @@ class GlasscuttingTest < ActiveSupport::TestCase
     # Destroy first glasscutting
     glasscutting1.destroy!
 
-    # Second glasscutting should become V1
+    # Second glasscutting should keep its typology unchanged
     glasscutting2.reload
-    assert_equal "V1", glasscutting2.typology
+    assert_equal "V2", glasscutting2.typology
   end
 end

--- a/Aberturas/test/models/project_test.rb
+++ b/Aberturas/test/models/project_test.rb
@@ -17,7 +17,7 @@ class ProjectTest < ActiveSupport::TestCase
       glass_type: "LAM",
       thickness: "4+4",
       color: "INC",
-      location: "DINTEL",
+      typology: "V1",
       height: 100,
       width: 50,
       price: 100.0
@@ -27,7 +27,7 @@ class ProjectTest < ActiveSupport::TestCase
       glass_type: "FLO",
       thickness: "3+3",
       color: "GRS",
-      location: "JAMBA_I",
+      typology: "V2",
       height: 200,
       width: 75,
       price: 200.0
@@ -36,7 +36,7 @@ class ProjectTest < ActiveSupport::TestCase
     # Create DVH
     dvh = project.dvhs.create!(
       innertube: 9,
-      location: "DINTEL",
+      typology: "V3",
       height: 150,
       width: 100,
       glasscutting1_type: "LAM",
@@ -62,7 +62,7 @@ class ProjectTest < ActiveSupport::TestCase
     assert_equal "V3", dvh.typology
   end
 
-  test "should reassign typologies when glasscutting is deleted" do
+  test "should maintain typologies when glasscutting is deleted" do
     project = Project.create!(
       name: "Test Project",
       phone: "123456789",
@@ -71,17 +71,17 @@ class ProjectTest < ActiveSupport::TestCase
 
     # Create glasscuttings
     glasscutting1 = project.glasscuttings.create!(
-      glass_type: "LAM", thickness: "4+4", color: "INC", location: "DINTEL",
+      glass_type: "LAM", thickness: "4+4", color: "INC", typology: "V1",
       height: 100, width: 50, price: 100.0
     )
     
     glasscutting2 = project.glasscuttings.create!(
-      glass_type: "FLO", thickness: "3+3", color: "GRS", location: "JAMBA_I",
+      glass_type: "FLO", thickness: "3+3", color: "GRS", typology: "V2",
       height: 200, width: 75, price: 200.0
     )
 
     dvh = project.dvhs.create!(
-      innertube: 9, location: "DINTEL", height: 150, width: 100,
+      innertube: 9, typology: "V3", height: 150, width: 100,
       glasscutting1_type: "LAM", glasscutting1_thickness: "4+4", glasscutting1_color: "INC",
       glasscutting2_type: "FLO", glasscutting2_thickness: "3+3", glasscutting2_color: "GRS",
       price: 300.0
@@ -105,12 +105,12 @@ class ProjectTest < ActiveSupport::TestCase
     glasscutting2.reload
     dvh.reload
 
-    # Assert typologies are reassigned
-    assert_equal "V1", glasscutting2.typology
-    assert_equal "V2", dvh.typology
+    # Assert typologies remain unchanged
+    assert_equal "V2", glasscutting2.typology
+    assert_equal "V3", dvh.typology
   end
 
-  test "should reassign typologies when dvh is deleted" do
+  test "should maintain typologies when dvh is deleted" do
     project = Project.create!(
       name: "Test Project",
       phone: "123456789",
@@ -118,19 +118,19 @@ class ProjectTest < ActiveSupport::TestCase
     )
 
     glasscutting = project.glasscuttings.create!(
-      glass_type: "LAM", thickness: "4+4", color: "INC", location: "DINTEL",
+      glass_type: "LAM", thickness: "4+4", color: "INC", typology: "V1",
       height: 100, width: 50, price: 100.0
     )
 
     dvh1 = project.dvhs.create!(
-      innertube: 9, location: "DINTEL", height: 150, width: 100,
+      innertube: 9, typology: "V2", height: 150, width: 100,
       glasscutting1_type: "LAM", glasscutting1_thickness: "4+4", glasscutting1_color: "INC",
       glasscutting2_type: "FLO", glasscutting2_thickness: "3+3", glasscutting2_color: "GRS",
       price: 300.0
     )
 
     dvh2 = project.dvhs.create!(
-      innertube: 12, location: "JAMBA_I", height: 200, width: 150,
+      innertube: 12, typology: "V3", height: 200, width: 150,
       glasscutting1_type: "COL", glasscutting1_thickness: "5+5", glasscutting1_color: "BRC",
       glasscutting2_type: "LAM", glasscutting2_thickness: "4+4", glasscutting2_color: "STB",
       price: 400.0
@@ -154,8 +154,8 @@ class ProjectTest < ActiveSupport::TestCase
     glasscutting.reload
     dvh2.reload
 
-    # Assert typologies are reassigned
+    # Assert typologies remain unchanged
     assert_equal "V1", glasscutting.typology
-    assert_equal "V2", dvh2.typology
+    assert_equal "V3", dvh2.typology
   end
 end

--- a/Aberturas/test/system/glasscuttings_test.rb
+++ b/Aberturas/test/system/glasscuttings_test.rb
@@ -25,7 +25,7 @@ class GlasscuttingsTest < ApplicationSystemTestCase
       sleep(0.5) # Wait for JavaScript to populate dependent selects
       find(".glass-thickness-select").select("3+3")
       find(".glass-color-select").select("INC")
-      find(".glass-location-select").select("DINTEL")
+      find(".typology-number-input").fill_in with: "1"  # This will create "V1"
       find("input[name='project[glasscuttings_attributes][][height]']").fill_in with: "120"
       find("input[name='project[glasscuttings_attributes][][width]']").fill_in with: "100"
     end


### PR DESCRIPTION
The method that automatically assigned typologies was removed, and it was also removed from the parameters of the dvh and glasscuttings. In addition, the location was removed from all forms and tables and replaced with typology. Due to these changes, the tests also had to be modified.